### PR TITLE
PDS-891: deprecate Feedback app by triggering new Feedback widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Here are the steps for deploying the Feedback widget to your website on an Apach
 <!-- PDS Feedback Widget -->
 <!-- Only add JQuery if you do not already include a library -->
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-<script src='https://www.google.com/recaptcha/api.js?render=explicit' async defer></script>
+<script src='https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit' async defer></script>
 <link rel="stylesheet" href="/feedback/css/feedback.css"  type="text/css" media="screen" />
 <script src="/feedback/js/modernizr-custom.js"></script>
 <script src="/feedback/js/config.js"></script>

--- a/feedback/js/feedback.js
+++ b/feedback/js/feedback.js
@@ -251,9 +251,7 @@ document.addEventListener("DOMContentLoaded", function(){
 			},
 
 			onloadCallback: function() {
-				// check URL - redirected from old feedback page?
 				if ( new URLSearchParams(window.location.search).get("feedback") === "true" ) {
-					window.history.replaceState( {}, document.title, "/" );
 					returnMethods.open();
 				}
 			},

--- a/feedback/js/feedback.js
+++ b/feedback/js/feedback.js
@@ -250,6 +250,14 @@ document.addEventListener("DOMContentLoaded", function(){
 
 			},
 
+			onloadCallback: function() {
+				// check URL - redirected from old feedback page?
+				if ( new URLSearchParams(window.location.search).get("feedback") === "true" ) {
+					window.history.replaceState( {}, document.title, "/" );
+					returnMethods.open();
+				}
+			},
+
 			captchaCallback: function( response ) {
 				if ( document.getElementById("feedback-comment").reportValidity() ) {
 					$.ajax({
@@ -285,6 +293,7 @@ document.addEventListener("DOMContentLoaded", function(){
 
 		};
 
+		window.onloadCallback = returnMethods.onloadCallback;
 		window.captchaCallback = returnMethods.captchaCallback;
 
 		glass.className = "feedback-glass";


### PR DESCRIPTION
The new function, onloadCallback(), must be added as a query string parameter to the URL which loads reCAPTCHA's API, i.e. `<script src="https://www.google.com/recaptcha/api.js?onload=onloadCallback&render=explicit" async defer></script>`.